### PR TITLE
bootstrap4/components.py: Load utils as .utils

### DIFF
--- a/bootstrap4/components.py
+++ b/bootstrap4/components.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.forms.utils import flatatt
 from django.utils.safestring import mark_safe
-from bootstrap4.utils import render_tag, add_css_class
+from .utils import render_tag, add_css_class
 
 from .text import text_value
 


### PR DESCRIPTION
- This is more flexible incase folks are installing this project
  under a different herirarchy such as /myproject/myapp/contrib/bootstrap4