### PR TITLE
Remove IE<9 compatibility stuff

### DIFF
--- a/bootstrap4/templates/bootstrap4/bootstrap4.html
+++ b/bootstrap4/templates/bootstrap4/bootstrap4.html
@@ -8,12 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block bootstrap4_title %}django-bootstrap4 template title{% endblock %}</title>
     {% bootstrap_css %}
-    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-    <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-    <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
-    <![endif]-->
     {% if 'javascript_in_head'|bootstrap_setting %}{% bootstrap_javascript jquery=True %}{% endif %}
     {% block bootstrap4_extra_head %}{% endblock %}
 </head>


### PR DESCRIPTION
Bootstrap 4 dropped support for all IE versions prior to 10.